### PR TITLE
Add tectonic and fonts to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,19 +17,25 @@
             url = "${releasesUrl}/download/${version}/macOS-11-anki-panky-${version}.tar.gz";
             sha256 = "HJX0C7YKTYzbkCUnww3N2VBRcMNhGvvwBX0YBTnO5Us=";
           };
-          phases = ["installPhase"];
+          phases = [ "installPhase" ];
           installPhase = ''
             mkdir -p $out/bin
             cp -R $src/anki-panky $out/bin/anki-panky
             chmod +x $out/bin/anki-panky
           '';
         };
+        fonts = pkgs.nerdfonts.override { fonts = [ "Hasklig" ]; };
       in
       {
         devShells.default = with pkgs; mkShell {
+          nativeBuildInputs = [
+            fonts
+          ];
+
           buildInputs = [
             ankiPanky
             pandoc
+            tectonic
           ];
         };
       });


### PR DESCRIPTION
The PDF engine was changed to tectonic, but it was missing from the nix flake.

Also, compiling the PDF fails on systems which don't have the Hasklug font installed, which we can also add to the flake for better reproducibility.