### PR TITLE
Nix Flake Improvements

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,20 +4,38 @@
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, utils }:
-    utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      utils,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+    in
+    utils.lib.eachSystem supportedSystems (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
         version = "0.0.0.3";
         releasesUrl = "https://github.com/kamalsacranie/anki-panky/releases";
+        src =
+          if system == "x86_64-darwin" then
+            pkgs.fetchzip {
+              url = "${releasesUrl}/download/${version}/macOS-11-anki-panky-${version}.tar.gz";
+              sha256 = "sha256-HJX0C7YKTYzbkCUnww3N2VBRcMNhGvvwBX0YBTnO5Us=";
+            }
+          else
+            pkgs.fetchzip {
+              url = "${releasesUrl}/download/${version}/ubuntu-latest-anki-panky-${version}.tar.gz";
+              sha256 = "sha256-0NlgyA/HWVDADj21K17xGqiRx9kIpx/5eOjOgQL6tsA=";
+            };
         ankiPanky = pkgs.stdenv.mkDerivation {
           name = "anki-panky";
-          version = "0.0.0.3";
-          src = pkgs.fetchzip {
-            url = "${releasesUrl}/download/${version}/macOS-11-anki-panky-${version}.tar.gz";
-            sha256 = "HJX0C7YKTYzbkCUnww3N2VBRcMNhGvvwBX0YBTnO5Us=";
-          };
-          phases = [ "installPhase" ];
+          inherit src version;
           installPhase = ''
             mkdir -p $out/bin
             cp -R $src/anki-panky $out/bin/anki-panky
@@ -26,17 +44,23 @@
         };
         fonts = pkgs.nerdfonts.override { fonts = [ "Hasklig" ]; };
       in
+      with pkgs;
       {
-        devShells.default = with pkgs; mkShell {
-          nativeBuildInputs = [
-            fonts
-          ];
+        devShells.default = mkShell {
+          nativeBuildInputs = [ fonts ];
 
           buildInputs = [
             ankiPanky
             pandoc
             tectonic
           ];
+
+          # Add necessary library dependencies
+          LD_LIBRARY_PATH = "${lib.makeLibraryPath [
+            gmp
+            zlib
+          ]}";
         };
-      });
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,18 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
-        version = "0.0.0.3";
+        version = "0.0.0.6";
         releasesUrl = "https://github.com/kamalsacranie/anki-panky/releases";
         src =
           if system == "x86_64-darwin" then
             pkgs.fetchzip {
               url = "${releasesUrl}/download/${version}/macOS-11-anki-panky-${version}.tar.gz";
-              sha256 = "sha256-HJX0C7YKTYzbkCUnww3N2VBRcMNhGvvwBX0YBTnO5Us=";
+              sha256 = "7kkfdx1vndheb63+m2HOLXo0wOYX4iReh9c7Ps/KYQk=";
             }
           else
             pkgs.fetchzip {
               url = "${releasesUrl}/download/${version}/ubuntu-latest-anki-panky-${version}.tar.gz";
-              sha256 = "sha256-0NlgyA/HWVDADj21K17xGqiRx9kIpx/5eOjOgQL6tsA=";
+              sha256 = "k5DQUI2JLVujkV2aZObAPn43m9QZ+aXPJwXpUKDuEDo=";
             };
         ankiPanky = pkgs.stdenv.mkDerivation {
           name = "anki-panky";


### PR DESCRIPTION
I'm using Linux and the flake uses the macOS release for the anki-panky binary, which doesn't work.

As such, I've refactored it to use the proper executable depending on the current system. I've also updated the release version as it seems to fix a few bugs and add new features.

**PS:** Since the anki-panky release binaries are only for Linux-x86_64 and macOS-x86_64, those are the two platforms that we can easily support. In the future it might be interesting to look into compiling it from source and adding it to nixpkgs, but right now I believe this is good enough.